### PR TITLE
lualpeg: pass LDFLAGS

### DIFF
--- a/recipes-devtools/lualpeg/lualpeg_1.0.2.bb
+++ b/recipes-devtools/lualpeg/lualpeg_1.0.2.bb
@@ -15,7 +15,7 @@ LUA_VERSION = "5.3"
 
 inherit autotools pkgconfig
 
-EXTRA_OEMAKE = "-f makefile LUA_V=${LUA_VERSION} LUADIR=${RECIPE_SYSROOT}/usr/lua"
+EXTRA_OEMAKE = "-f makefile LUA_V=${LUA_VERSION} LUADIR=${RECIPE_SYSROOT}/usr/lua 'CC=${CC} ${LDFLAGS}'"
 CFLAGS_append = " -I${LUADIR} -fPIC"
 
 do_configure() {


### PR DESCRIPTION
Pass LDFLAGS in the CC command so that lpeg.so symbols hash style
includes GNU_HASH. Fixes the following build error:

ERROR: lualpeg-1.0.2-r0 do_package_qa: QA Issue: File /usr/lib/lua/5.3/lpeg.so in package lualpeg doesn't have GNU_HASH (didn't pass LDFLAGS?) [ldflags]